### PR TITLE
[Feat] 게시글 CRUD 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	//AWS S3
 	implementation platform('software.amazon.awssdk:bom:2.20.56')
 	implementation 'software.amazon.awssdk:s3'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/example/backend/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/example/backend/domain/auth/dto/SignupRequest.java
@@ -1,5 +1,6 @@
 package com.example.backend.domain.auth.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -13,6 +14,10 @@ public class SignupRequest {
     @Size(min = 2, max = 20)
     private String username;
 
+    @Email
+    @NotBlank
+    private String email;
+
     @NotBlank
     @Size(min = 6, max = 100)
     private String password;
@@ -20,8 +25,9 @@ public class SignupRequest {
     @NotBlank
     private String confirmPassword;
 
-    public SignupRequest(String username, String password, String confirmPassword) {
+    public SignupRequest(String username, String email, String password, String confirmPassword) {
         this.username = username;
+        this.email = email;
         this.password = password;
         this.confirmPassword = confirmPassword;
     }

--- a/src/main/java/com/example/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/backend/domain/auth/service/AuthService.java
@@ -39,6 +39,7 @@ public class AuthService {
 
         Users user = Users.builder()
                 .username(request.getUsername())
+                .email(request.getEmail())
                 .password(encodedPassword)
                 .role(Role.USER)
                 .build();

--- a/src/main/java/com/example/backend/domain/global/config/S3Config.java
+++ b/src/main/java/com/example/backend/domain/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.example.backend.domain.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+}

--- a/src/main/java/com/example/backend/domain/global/s3/S3Service.java
+++ b/src/main/java/com/example/backend/domain/global/s3/S3Service.java
@@ -1,0 +1,60 @@
+package com.example.backend.domain.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile file) throws IOException {
+        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+        return getFileUrl(fileName);
+    }
+
+    public void deleteFile(String fileName) {
+
+        String key = extractKeyFromUrl(fileName);
+
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build());
+    }
+
+    //S3에 저장된 파일 URL 반환 (서울 리전 기준)
+    private String getFileUrl(String key) {
+        return "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/" + key;
+    }
+
+    //파일 URL에서 S3 key 추출
+    private String extractKeyFromUrl(String fileUrl) {
+        int idx = fileUrl.lastIndexOf("/");
+        return fileUrl.substring(idx + 1);
+    }
+
+
+}

--- a/src/main/java/com/example/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/backend/domain/post/controller/PostController.java
@@ -1,0 +1,70 @@
+package com.example.backend.domain.post.controller;
+
+import com.example.backend.domain.post.dto.PostCreateRequest;
+import com.example.backend.domain.post.dto.PostResponse;
+import com.example.backend.domain.post.dto.PostUpdateRequest;
+import com.example.backend.domain.post.entity.Post;
+import com.example.backend.domain.post.service.PostService;
+import com.example.backend.domain.security.adapter.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PostResponse> createPost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart("postCreateRequest") PostCreateRequest postCreateRequest,
+            @RequestPart("images") List<MultipartFile> images
+    ) {
+        Long userId = userDetails.getUserId();
+        PostResponse response = postService.createPost(userId, postCreateRequest, images);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{storeId}")
+    public ResponseEntity<Page<PostResponse>> getPostsByStore(
+            @PathVariable Long storeId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(postService.getPostsByStore(storeId, pageable));
+    }
+
+    @GetMapping("/{storeId}/{postId}")
+    public ResponseEntity<PostResponse> getDetailPosts(@PathVariable Long storeId,
+                                                       @PathVariable Long postId) {
+        return ResponseEntity.ok(postService.getPostDetail(postId));
+    }
+
+    @PatchMapping(value = "/{storeId}/{postId}",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PostResponse> updatePost(
+            @PathVariable Long postId,
+            @PathVariable Long storeId,
+            @RequestPart("postUpdateRequest") PostUpdateRequest postUpdateRequest,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    ) {
+        PostResponse updated = postService.updatePost(postId, postUpdateRequest, images);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{storeId}/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId, @PathVariable Long storeId) {
+        postService.deletePost(postId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/backend/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/example/backend/domain/post/dto/PostCreateRequest.java
@@ -1,0 +1,15 @@
+package com.example.backend.domain.post.dto;
+
+import lombok.*;
+
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostCreateRequest {
+
+    private String title;
+    private String content;
+    private String location;
+    private Long storeId;
+}

--- a/src/main/java/com/example/backend/domain/post/dto/PostMediaResponse.java
+++ b/src/main/java/com/example/backend/domain/post/dto/PostMediaResponse.java
@@ -1,0 +1,13 @@
+package com.example.backend.domain.post.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostMediaResponse {
+    private Long id;
+    private String mediaUrl;
+    private Integer sequence;
+}

--- a/src/main/java/com/example/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/example/backend/domain/post/dto/PostResponse.java
@@ -1,0 +1,37 @@
+package com.example.backend.domain.post.dto;
+
+import com.example.backend.domain.post.entity.Post;
+import com.example.backend.domain.store.entity.Store;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PostResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String location;
+    private Long userId;
+    private String username;
+    private List<String> mediaUrls;
+    private Long storeId;
+    private String storeName;
+
+    public static PostResponse from(Post post, List<String> mediaUrl, Store store) {
+        return PostResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .location(post.getLocation())
+                .userId(post.getUser().getId())
+                .username(post.getUser().getUsername())
+                .mediaUrls(mediaUrl)
+                .storeId(store.getId())
+                .storeName(store.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/backend/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/example/backend/domain/post/dto/PostUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.example.backend.domain.post.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostUpdateRequest {
+    private String title;
+    private String content;
+    private String location;
+    //유지할 이미지의 S3 URL 리스트
+    private List<String> keepMediaUrls;
+    private Long storeId;
+}

--- a/src/main/java/com/example/backend/domain/post/entity/Post.java
+++ b/src/main/java/com/example/backend/domain/post/entity/Post.java
@@ -1,16 +1,66 @@
 package com.example.backend.domain.post.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import com.example.backend.domain.global.BaseEntity;
+import com.example.backend.domain.store.entity.Store;
+import com.example.backend.domain.user.entity.Users;
+import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
-public class Post {
+@NoArgsConstructor
+@Table(name = "posts")
+public class Post extends BaseEntity {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Column(length = 4096)
+    private String images;
+
+    private String location;
 
     private String title;
 
     private String content;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostMedia> mediaList = new ArrayList<>();
+
+    private Post(Users user, Store store, String location, String title, String content) {
+        this.user = user;
+        this.store = store;
+        this.location = location;
+        this.title = title;
+        this.content = content;
+    }
+
+
+
+    public static Post of(Users user,Store store, String location, String title, String content) {
+        return new Post(user, store, location, title, content);
+    }
+
+    public void update(String title, String content, String location) {
+        this.title = title;
+        this.content = content;
+        this.location = location;
+    }
+
 }

--- a/src/main/java/com/example/backend/domain/post/entity/PostMedia.java
+++ b/src/main/java/com/example/backend/domain/post/entity/PostMedia.java
@@ -1,0 +1,32 @@
+package com.example.backend.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "post_media")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostMedia {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(length = 1024, nullable = false)
+    private String mediaUrl;
+
+    private PostMedia(Post post, String mediaUrl) {
+        this.post = post;
+        this.mediaUrl = mediaUrl;
+    }
+
+    public static PostMedia of(Post post, String mediaUrl) {
+        return new PostMedia(post, mediaUrl);
+    }
+}

--- a/src/main/java/com/example/backend/domain/post/repository/PostMediaRepository.java
+++ b/src/main/java/com/example/backend/domain/post/repository/PostMediaRepository.java
@@ -1,0 +1,16 @@
+package com.example.backend.domain.post.repository;
+
+import com.example.backend.domain.post.entity.Post;
+import com.example.backend.domain.post.entity.PostMedia;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {
+
+    List<PostMedia> findByPostId(Long postId);
+
+    List<PostMedia> findAllByPost(Post post);
+}

--- a/src/main/java/com/example/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/backend/domain/post/repository/PostRepository.java
@@ -1,9 +1,18 @@
 package com.example.backend.domain.post.repository;
 
 import com.example.backend.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+//    Page<Post> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    Page<Post> findAllByStoreIdOrderByCreatedAtDesc(Long storeId, Pageable pageable);
+
 }

--- a/src/main/java/com/example/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/example/backend/domain/post/service/PostService.java
@@ -1,0 +1,148 @@
+package com.example.backend.domain.post.service;
+
+import com.example.backend.domain.global.s3.S3Service;
+import com.example.backend.domain.post.dto.PostCreateRequest;
+import com.example.backend.domain.post.dto.PostResponse;
+import com.example.backend.domain.post.dto.PostUpdateRequest;
+import com.example.backend.domain.post.entity.Post;
+import com.example.backend.domain.post.entity.PostMedia;
+import com.example.backend.domain.post.repository.PostMediaRepository;
+import com.example.backend.domain.post.repository.PostRepository;
+import com.example.backend.domain.store.entity.Store;
+import com.example.backend.domain.store.repository.StoreRepository;
+import com.example.backend.domain.user.entity.Users;
+import com.example.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final PostMediaRepository postMediaRepository;
+    private final S3Service s3Service;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public PostResponse createPost(Long userId, PostCreateRequest postCreateRequest, List<MultipartFile> imageFiles) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Store store = storeRepository.findOrThrow(postCreateRequest.getStoreId());
+
+        List<String> mediaUrls = imageFiles.stream()
+                .map(file -> {
+                    try {
+                        return s3Service.uploadFile(file);
+                    } catch (IOException e) {
+                        throw new RuntimeException("S3 업로드 실패", e);
+                    }
+                })
+                .collect(Collectors.toList());
+
+        if (mediaUrls == null || mediaUrls.isEmpty()) {
+            throw new IllegalArgumentException("MediaUrls cannot be empty");
+        }
+
+        //post 생성
+        Post post = Post.of(user, store, postCreateRequest.getLocation(), postCreateRequest.getTitle(), postCreateRequest.getContent());
+        postRepository.save(post);
+
+        //정적 팩토리 메서드 이미지 등록(추후 CQRS 패턴 대비)
+        List<PostMedia> mediaList = mediaUrls.stream()
+                .map(url -> PostMedia.of(post, url))
+                .collect(Collectors.toList());
+        postMediaRepository.saveAll(mediaList);
+
+        return PostResponse.from(post, mediaUrls, store);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostResponse> getPostsByStore(Long storeId, Pageable pageable) {
+        Page<Post> page = postRepository.findAllByStoreIdOrderByCreatedAtDesc(storeId, pageable);
+
+        return page.map(post -> {
+            List<String> mediaUrls = postMediaRepository.findAllByPost(post).stream()
+                    .map(PostMedia::getMediaUrl)
+                    .collect(Collectors.toList());
+            return PostResponse.from(post, mediaUrls, post.getStore());
+        });
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponse getPostDetail(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        List<String> mediaUrls = postMediaRepository.findAllByPost(post).stream()
+                .map(PostMedia::getMediaUrl)
+                .collect(Collectors.toList());
+        return PostResponse.from(post, mediaUrls, post.getStore());
+    }
+
+    @Transactional
+    public PostResponse updatePost(Long postId, PostUpdateRequest postUpdateRequest, List<MultipartFile> imageFiles) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+
+        //기존 이미지 조회
+        List<PostMedia> allPosts = postMediaRepository.findAllByPost(post);
+
+        //NPE 방지
+        List<String> keepMediaUrls = postUpdateRequest.getKeepMediaUrls() != null
+                ? postUpdateRequest.getKeepMediaUrls()
+                : List.of();
+
+        List<PostMedia> toDelete = allPosts.stream()
+                .filter(media -> !keepMediaUrls.contains(media.getMediaUrl()))
+                .toList();
+
+        for (PostMedia media : toDelete) {
+            s3Service.deleteFile(media.getMediaUrl());
+        }
+        postMediaRepository.deleteAll(toDelete);
+
+
+        if(imageFiles != null && !imageFiles.isEmpty()) {
+            List<String> newMediaUrls = imageFiles.stream().map(file -> {
+                try {
+                    return s3Service.uploadFile(file);
+                } catch (IOException e) {
+                    throw new RuntimeException("S3 업로드 실패", e);
+                }
+            }).toList();
+            List<PostMedia> newMedia = newMediaUrls.stream().map(url -> PostMedia.of(post, url)).collect(Collectors.toList());
+            postMediaRepository.saveAll(newMedia);
+        }
+
+        post.update(postUpdateRequest.getTitle(), postUpdateRequest.getContent(), postUpdateRequest.getLocation());
+
+        List<String> mediaUrls = postMediaRepository.findAllByPost(post)
+                .stream()
+                .map(PostMedia::getMediaUrl).toList();
+        return PostResponse.from(post, mediaUrls, post.getStore());
+    }
+
+    @Transactional
+    public void deletePost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+
+        List<PostMedia> medias = postMediaRepository.findAllByPost(post);
+
+        // S3에서 이미지 삭제
+        for (PostMedia media : medias) {
+            s3Service.deleteFile(media.getMediaUrl());
+        }
+        postRepository.delete(post);
+    }
+}

--- a/src/test/java/com/example/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/backend/domain/post/service/PostServiceTest.java
@@ -1,0 +1,167 @@
+package com.example.backend.domain.post.service;
+
+import com.example.backend.domain.global.s3.S3Service;
+import com.example.backend.domain.post.dto.PostCreateRequest;
+import com.example.backend.domain.post.dto.PostResponse;
+import com.example.backend.domain.post.dto.PostUpdateRequest;
+import com.example.backend.domain.post.entity.Post;
+import com.example.backend.domain.post.entity.PostMedia;
+import com.example.backend.domain.post.repository.PostMediaRepository;
+import com.example.backend.domain.post.repository.PostRepository;
+import com.example.backend.domain.store.entity.Store;
+import com.example.backend.domain.store.repository.StoreRepository;
+import com.example.backend.domain.user.entity.Users;
+import com.example.backend.domain.user.repository.UserRepository;
+import com.example.backend.support.annotation.ServiceTest;
+import com.example.backend.support.fixture.PostFixture;
+import com.example.backend.support.fixture.StoreFixture;
+import com.example.backend.support.fixture.UsersFixture;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@ServiceTest
+public class PostServiceTest {
+
+    @Autowired
+    PostService postService;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    StoreRepository storeRepository;
+    @Autowired
+    PostMediaRepository postMediaRepository;
+
+    @MockitoBean
+    S3Service s3Service;
+
+    @Test
+    void createPost() {
+        Users user = UsersFixture.김회원();
+        userRepository.save(user);
+
+        PostFixture postFixture = PostFixture.이미지_포함_게시글;
+        PostCreateRequest postCreateRequest = postFixture.toCreateRequest();
+        List<MultipartFile> files = postFixture.getMediaUrls();
+
+        try {
+            Mockito.when(s3Service.uploadFile(any(MultipartFile.class)))
+                    .thenReturn("http://mock-s3-url/img1.png");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        PostResponse postResponse = postService.createPost(user.getId(), postCreateRequest, files);
+
+        assertEquals(postFixture.getTitle(), postResponse.getTitle());
+        assertEquals(postFixture.getContent(), postResponse.getContent());
+        assertEquals(postFixture.getLocation(), postResponse.getLocation());
+        assertEquals(user.getId(), postResponse.getUserId());
+    }
+
+    @Test
+    void updatePost() {
+        Users user = UsersFixture.김회원();
+        Store store = StoreFixture.과일가게(user);
+        userRepository.save(user);
+        storeRepository.save(store);
+
+        PostFixture postFixture = PostFixture.이미지_포함_게시글;
+        PostCreateRequest postCreateRequest = postFixture.toCreateRequest();
+        List<MultipartFile> files = postFixture.getMediaUrls();
+
+        try {
+            Mockito.when(s3Service.uploadFile(any(MultipartFile.class)))
+                    .thenReturn("http://mock-s3-url/img1.png", "http://mock-s3-url/img2.png");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        PostResponse postResponse = postService.createPost(user.getId(), postCreateRequest, files);
+
+        Long postId = postResponse.getId();
+        Long storeId = store.getId();
+
+        List<String> keepMediaUrls = List.of("http://mock-s3-url/img1.png");
+
+        MockMultipartFile newImage = new MockMultipartFile(
+                "images", "img3.png", "image/png", "c".getBytes()
+        );
+        List<MultipartFile> newFiles = List.of(newImage);
+
+        try {
+            Mockito.when(s3Service.uploadFile(any(MultipartFile.class)))
+                    .thenReturn("http://mock-s3-url/img3.png");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        PostUpdateRequest updateRequest = PostUpdateRequest.builder()
+                .title("수정된 제목")
+                .content("수정된 내용")
+                .location("수정된 장소")
+                .keepMediaUrls(keepMediaUrls)
+                .storeId(storeId)
+                .build();
+
+        PostResponse updated = postService.updatePost(postId, updateRequest, newFiles);
+
+        assertEquals("수정된 제목", updated.getTitle());
+        assertEquals("수정된 내용", updated.getContent());
+        assertEquals("수정된 장소", updated.getLocation());
+        assertEquals(2, updated.getMediaUrls().size());
+        assertTrue(updated.getMediaUrls().contains("http://mock-s3-url/img1.png")); // 기존 이미지 유지
+        assertTrue(updated.getMediaUrls().contains("http://mock-s3-url/img3.png")); // 새 이미지 추가
+        assertFalse(updated.getMediaUrls().contains("http://mock-s3-url/img2.png")); // img2.png는 삭제
+    }
+
+    @Test
+    void deletePost() {
+        Users user = UsersFixture.김회원();
+        userRepository.save(user);
+        Store store = StoreFixture.과일가게(user);
+        storeRepository.save(store);
+
+        PostFixture postFixture = PostFixture.이미지_포함_게시글;
+        PostCreateRequest postCreateRequest = postFixture.toCreateRequest();
+        List<MultipartFile> files = postFixture.getMediaUrls();
+
+        try {
+            Mockito.when(s3Service.uploadFile(any(MultipartFile.class)))
+                    .thenReturn("http://mock-s3-url/img1.png", "http://mock-s3-url/img2.png");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        PostResponse postResponse = postService.createPost(user.getId(), postCreateRequest, files);
+        Long postId = postResponse.getId();
+
+        // S3Service Mock: 삭제 호출 기대
+        Mockito.doNothing().when(s3Service).deleteFile(anyString());
+
+        // 2. 게시글 삭제
+        postService.deletePost(postId);
+
+        // 3. 실제로 DB에서 삭제되었는지 검증
+        assertFalse(postRepository.findById(postId).isPresent());
+
+        // 4. 이미지도 PostMedia에서 삭제되었는지 검증 (optional)
+        List<PostMedia> medias = postMediaRepository.findByPostId(postId);
+        assertTrue(medias.isEmpty());
+
+        // 5. S3Service의 deleteFile이 2회 호출되었는지 검증 (옵션)
+        Mockito.verify(s3Service, Mockito.times(2)).deleteFile(anyString());
+    }
+
+}

--- a/src/test/java/com/example/backend/support/fixture/PostFixture.java
+++ b/src/test/java/com/example/backend/support/fixture/PostFixture.java
@@ -1,0 +1,44 @@
+package com.example.backend.support.fixture;
+
+import com.example.backend.domain.post.dto.PostCreateRequest;
+import com.example.backend.domain.post.entity.Post;
+import lombok.Getter;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+public enum PostFixture {
+
+    이미지_포함_게시글(
+            "테스트 제목",
+            "테스트 내용",
+            "서울",
+            List.of(
+                    new MockMultipartFile("images", "img1.png", "image/png", "a".getBytes()),
+                    new MockMultipartFile("images", "img2.png", "image/png", "b".getBytes())
+            ),
+            1L
+    );
+
+    private final String title;
+    private final String content;
+    private final String location;
+    private final List<MultipartFile> mediaUrls;
+    private final Long storeId;
+
+    PostFixture(String title, String content, String location, List<MultipartFile> mediaUrls, Long storeId) {
+        this.title = title;
+        this.content = content;
+        this.location = location;
+        this.mediaUrls = mediaUrls;
+        this.storeId = storeId;
+    }
+
+    public PostCreateRequest toCreateRequest() {
+        return new PostCreateRequest(
+                title, content, location, storeId);
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,11 +17,24 @@ spring:
       hibernate:
         format_sql: true
     open-in-view: false
-
+  config:
+    import:
+      - optional:file:./env/db.env.properties
+      - optional:file:./.env.properties
 logging:
   level:
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 
+#AWS S3 관련 설정
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucketName: ${BUCKET_NAME}
 
 jwt:
   secret: CwJArxGyhBEEAXl2uVV8BTLcWLb30YHVPa/0cHaF/zd25IYyS8Isep2SxHDSJYSrxnsRbUmLqoqEorh+odLlFw==


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
게시글 CRUD 기능 구현

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 게시글 생성/조회/수정/삭제 기능 구현
- 생성 및 수정 시, aws S3를 사용하여 이미지 업로드 기능 구현
-


## 📸 스크린샷 (선택)
<img width="1028" height="734" alt="스크린샷 2025-07-21 오후 5 34 31" src="https://github.com/user-attachments/assets/1fdb9756-3668-409e-8731-51be00279c61" />
<img width="1028" height="734" alt="스크린샷 2025-07-21 오후 5 39 56" src="https://github.com/user-attachments/assets/a6721938-51f9-48eb-93ad-1d91ff15d91b" />
<img width="1028" height="734" alt="스크린샷 2025-07-21 오후 5 39 02" src="https://github.com/user-attachments/assets/89db6a4d-2c80-4f5d-8a97-652856b0ecef" />



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
- 에러코드 구체화
- 현재 게시글 상세 조회, 수정, 삭제 시의 경로가 "/api/v1/posts/{storeId}/{postId}"로 되어있음
추후 Store관련 Controller에서 게시글 상세 조회, 수정, 삭제가 가능하도록 변경할지 논의 필요

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number

<!--- closes #이슈번호 ex) closes #123 -->
#7 