### PR TITLE
[Feat] 가게 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/example/backend/domain/like/controller/StoreLikeController.java
+++ b/src/main/java/com/example/backend/domain/like/controller/StoreLikeController.java
@@ -1,0 +1,26 @@
+package com.example.backend.domain.like.controller;
+
+import com.example.backend.domain.like.dto.StoreLikeRequest;
+import com.example.backend.domain.like.dto.StoreLikeResponse;
+import com.example.backend.domain.like.repository.StoreLikeRepository;
+import com.example.backend.domain.like.service.StoreLikeService;
+import com.example.backend.domain.security.adapter.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/StoreLike")
+@RequiredArgsConstructor
+public class StoreLikeController {
+    private final StoreLikeService storeLikeService;
+    @PostMapping
+    public ResponseEntity<StoreLikeResponse> likeStore(@RequestBody StoreLikeRequest dto, @AuthenticationPrincipal CustomUserDetails user){
+        return ResponseEntity.ok(storeLikeService.likeStore(dto.storeId(),user.getUserId()));
+    }
+
+}

--- a/src/main/java/com/example/backend/domain/like/dto/StoreLikeRequest.java
+++ b/src/main/java/com/example/backend/domain/like/dto/StoreLikeRequest.java
@@ -1,0 +1,10 @@
+package com.example.backend.domain.like.dto;
+
+
+import com.example.backend.domain.like.entity.StoreLike;
+import org.springframework.web.bind.annotation.GetMapping;
+
+public record StoreLikeRequest (
+        Long storeId
+){
+}

--- a/src/main/java/com/example/backend/domain/like/dto/StoreLikeResponse.java
+++ b/src/main/java/com/example/backend/domain/like/dto/StoreLikeResponse.java
@@ -1,0 +1,7 @@
+package com.example.backend.domain.like.dto;
+
+public record StoreLikeResponse(
+    boolean becomeLike
+) {
+
+}

--- a/src/main/java/com/example/backend/domain/like/dto/StoreLikeResponse.java
+++ b/src/main/java/com/example/backend/domain/like/dto/StoreLikeResponse.java
@@ -3,5 +3,10 @@ package com.example.backend.domain.like.dto;
 public record StoreLikeResponse(
     boolean becomeLike
 ) {
-
+    public static StoreLikeResponse pressStoreLike() {
+        return new StoreLikeResponse(true);
+    }
+    public static StoreLikeResponse cancleStoreLike(){
+        return new StoreLikeResponse(false);
+    }
 }

--- a/src/main/java/com/example/backend/domain/like/entity/StoreLike.java
+++ b/src/main/java/com/example/backend/domain/like/entity/StoreLike.java
@@ -1,13 +1,31 @@
 package com.example.backend.domain.like.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import com.example.backend.domain.global.BaseEntity;
+import com.example.backend.domain.member.entity.Member;
+import com.example.backend.domain.store.entity.Store;
+import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-public class StoreLike {
+@NoArgsConstructor
+public class StoreLike extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    public StoreLike(Member member,Store store){
+        this.member=member;
+        this.store=store;
+    }
 }

--- a/src/main/java/com/example/backend/domain/like/repository/StoreLikeRepository.java
+++ b/src/main/java/com/example/backend/domain/like/repository/StoreLikeRepository.java
@@ -1,9 +1,16 @@
 package com.example.backend.domain.like.repository;
 
 import com.example.backend.domain.like.entity.StoreLike;
+import com.example.backend.domain.member.entity.Member;
+import com.example.backend.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface StoreLikeRepository extends JpaRepository<StoreLike,Long> {
+    Optional<StoreLike> findByMemberAndStore(Member member, Store store);
+    List<StoreLike> findAllByMember(Member member);
 }

--- a/src/main/java/com/example/backend/domain/like/service/StoreLikeService.java
+++ b/src/main/java/com/example/backend/domain/like/service/StoreLikeService.java
@@ -27,12 +27,13 @@ public class StoreLikeService {
         Optional<StoreLike> storeLike = storeLikeRepository.findByMemberAndStore(member,store);
         if(storeLike.isPresent()){
             storeLikeRepository.delete(storeLike.get());
-            return new StoreLikeResponse(false);
+            return StoreLikeResponse.cancleStoreLike();
         }
-        else{
+        if(storeLike.isEmpty()){
             storeLikeRepository.save(new StoreLike(member, store));
-            return new StoreLikeResponse(true);
+            return StoreLikeResponse.pressStoreLike();
         }
+        throw new IllegalStateException("좋아요 처리 실패");
     }
 
 }

--- a/src/main/java/com/example/backend/domain/like/service/StoreLikeService.java
+++ b/src/main/java/com/example/backend/domain/like/service/StoreLikeService.java
@@ -1,0 +1,38 @@
+package com.example.backend.domain.like.service;
+
+import com.example.backend.domain.like.dto.StoreLikeRequest;
+import com.example.backend.domain.like.dto.StoreLikeResponse;
+import com.example.backend.domain.like.entity.StoreLike;
+import com.example.backend.domain.like.repository.StoreLikeRepository;
+import com.example.backend.domain.member.entity.Member;
+import com.example.backend.domain.member.repository.MemberRepository;
+import com.example.backend.domain.store.dto.StoreResponse;
+import com.example.backend.domain.store.entity.Store;
+import com.example.backend.domain.store.repository.StoreRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class StoreLikeService {
+    private final StoreLikeRepository storeLikeRepository;
+    private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
+    public StoreLikeResponse likeStore(Long storeId, Long memberId){
+        Member member = memberRepository.findOrThrow(memberId);
+        Store store = storeRepository.findOrThrow(storeId);
+        Optional<StoreLike> storeLike = storeLikeRepository.findByMemberAndStore(member,store);
+        if(storeLike.isPresent()){
+            storeLikeRepository.delete(storeLike.get());
+            return new StoreLikeResponse(false);
+        }
+        else{
+            storeLikeRepository.save(new StoreLike(member, store));
+            return new StoreLikeResponse(true);
+        }
+    }
+
+}

--- a/src/test/java/com/example/backend/domain/like/StoreLikeSerivceTest.java
+++ b/src/test/java/com/example/backend/domain/like/StoreLikeSerivceTest.java
@@ -1,0 +1,41 @@
+package com.example.backend.domain.like;
+
+import com.example.backend.domain.like.dto.StoreLikeResponse;
+import com.example.backend.domain.like.repository.StoreLikeRepository;
+import com.example.backend.domain.like.service.StoreLikeService;
+import com.example.backend.domain.member.entity.Member;
+import com.example.backend.domain.member.repository.MemberRepository;
+import com.example.backend.domain.store.entity.Store;
+import com.example.backend.domain.store.repository.StoreRepository;
+import com.example.backend.support.annotation.ServiceTest;
+import com.example.backend.support.fixture.MemberFixture;
+import com.example.backend.support.fixture.StoreFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@ServiceTest
+public class StoreLikeSerivceTest {
+    @Autowired
+    StoreLikeService storeLikeService;
+    @Autowired
+    StoreLikeRepository storeLikeRepository;
+    @Autowired
+    StoreRepository storeRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Test
+    void 가게에_좋아요_좋아요취소_스위칭(){
+        Member member = MemberFixture.김회원();
+        memberRepository.save(member);
+        Store store = StoreFixture.과일가게(member);
+        storeRepository.save(store);
+        Assertions.assertThat(storeLikeRepository.findByMemberAndStore(member,store)).isEmpty();
+        StoreLikeResponse storeLikeResponse = storeLikeService.likeStore(member.getId(), store.getId());
+
+        Assertions.assertThat(storeLikeResponse.becomeLike()).isEqualTo(true);
+        StoreLikeResponse storeLikeResponse2 = storeLikeService.likeStore(member.getId(), store.getId());
+        Assertions.assertThat(storeLikeResponse2.becomeLike()).isEqualTo(false);
+
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용 요약
가게 좋아요 기능 구현.


## 🛠️ 작업 내용

- 가게 좋아요 기능 구현 (일반적인 좋아요 형식으로 동일 요청으로 좋아요 and 취소 병행)


## 📸 스크린샷 (선택)

<img width="438" height="112" alt="image" src="https://github.com/user-attachments/assets/64639b3b-3780-40b8-824d-93376d92ab3b" />


## 💬 공유사항 to 리뷰어

특정 가게의 좋아요 수 조회, 특정 멤버가 좋아요 한 가게목록 조회를
어느 컨트롤러에서 담당할지 판단하기 어려워서 해당 기능만 커밋합니다. 조언부탁드려요


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number

closes #23 
