### PR TITLE
[Feat] 상점 이벤트 발생 시 해당 상점 좋아요한 회원에게 알림 전송 기능 구현

### DIFF
--- a/src/main/java/com/example/backend/domain/alarm/controller/AlarmCommandController.java
+++ b/src/main/java/com/example/backend/domain/alarm/controller/AlarmCommandController.java
@@ -31,4 +31,13 @@ public class AlarmCommandController {
         alarmCommandService.deleteAlarm(alarmId);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "알림 개별 읽음 처리", description = "특정 알림을 읽음 처리합니다.")
+    @ApiResponse(responseCode = "204", description = "읽음 처리 성공")
+    @PostMapping("/{alarmId}/read")
+    public ResponseEntity<Void> readAlarm(@AuthenticationPrincipal CustomUserDetails user,
+                                          @PathVariable Long alarmId) {
+        alarmCommandService.readAlarm(user.getUserId(), alarmId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/backend/domain/alarm/dto/AlarmResponse.java
+++ b/src/main/java/com/example/backend/domain/alarm/dto/AlarmResponse.java
@@ -1,6 +1,8 @@
 package com.example.backend.domain.alarm.dto;
 
 import com.example.backend.domain.alarm.entity.Alarm;
+import com.example.backend.domain.alarm.entity.AlarmType;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -8,7 +10,9 @@ public record AlarmResponse(
         Long id,
         String content,
         Boolean isRead,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        AlarmType type,
+        String targetUrl
 ) {
 
     public static AlarmResponse from(Alarm alarm) {
@@ -16,7 +20,9 @@ public record AlarmResponse(
                 alarm.getId(),
                 alarm.getContent(),
                 alarm.getIsRead(),
-                alarm.getCreatedAt()
+                alarm.getCreatedAt(),
+                alarm.getType(),
+                alarm.getTargetUrl()
         );
     }
 

--- a/src/main/java/com/example/backend/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/example/backend/domain/alarm/entity/Alarm.java
@@ -27,10 +27,19 @@ public class Alarm extends BaseEntity {
 
     private Boolean isDeleted = false; // 삭제 여부
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AlarmType type;          // 알림 유형
+
+    @Column(length = 2048)
+    private String targetUrl;
+
     @Builder
-    public Alarm(Member member, String content) {
+    public Alarm(Member member, String content, AlarmType type, String targetUrl) {
         this.member = member;
         this.content = content;
+        this.type = type;
+        this.targetUrl = targetUrl;
         this.isRead = false;
         this.isDeleted = false;
     }

--- a/src/main/java/com/example/backend/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/com/example/backend/domain/alarm/entity/AlarmType.java
@@ -1,0 +1,7 @@
+package com.example.backend.domain.alarm.entity;
+
+public enum AlarmType {
+    NEW_EVENT,
+    COMMENT,
+    SYSTEM
+}

--- a/src/main/java/com/example/backend/domain/alarm/service/command/AlarmCommandService.java
+++ b/src/main/java/com/example/backend/domain/alarm/service/command/AlarmCommandService.java
@@ -9,6 +9,7 @@ public class AlarmCommandService {
     private final AlarmReadAllService alarmReadAllService;
     private final AlarmDeleteService alarmDeleteService;
     private final AlarmCreateService alarmCreateService;
+    private final AlarmReadService alarmReadService;
 
     public void readAll(Long memberId) {
         alarmReadAllService.readAll(memberId);
@@ -20,5 +21,9 @@ public class AlarmCommandService {
 
     public void sendToUser(Long memberId, String message) {
         alarmCreateService.create(memberId, message);
+    }
+
+    public void readAlarm(Long memberId, Long alarmId) {
+        alarmReadService.read(memberId, alarmId);
     }
 }

--- a/src/main/java/com/example/backend/domain/alarm/service/command/AlarmCreateService.java
+++ b/src/main/java/com/example/backend/domain/alarm/service/command/AlarmCreateService.java
@@ -1,6 +1,7 @@
 package com.example.backend.domain.alarm.service.command;
 
 import com.example.backend.domain.alarm.entity.Alarm;
+import com.example.backend.domain.alarm.entity.AlarmType;
 import com.example.backend.domain.alarm.repository.AlarmRepository;
 import com.example.backend.domain.alarm.repository.EmitterRepository;
 import com.example.backend.domain.member.entity.Member;
@@ -23,6 +24,14 @@ public class AlarmCreateService {
     private final EmitterRepository emitterRepository;
 
     public void create(Long memberId, String message) {
+        create(memberId, message, AlarmType.SYSTEM, null); // 기본값 SYSTEM + targetUrl 없음
+    }
+
+    public void create(Long memberId, String message, AlarmType type) {
+        create(memberId, message, type, null); // targetUrl 없음
+    }
+
+    public void create(Long memberId, String message, AlarmType type, String targetUrl) {
         Member member = findOrThrow(memberId);
         SseEmitter emitter = emitterRepository.get(memberId);
         if (emitter != null) {
@@ -36,6 +45,8 @@ public class AlarmCreateService {
         Alarm alarm = Alarm.builder()
                 .member(member)
                 .content(message)
+                .type(type)
+                .targetUrl(targetUrl)
                 .build();
         alarmRepository.save(alarm);
     }

--- a/src/main/java/com/example/backend/domain/alarm/service/command/AlarmReadService.java
+++ b/src/main/java/com/example/backend/domain/alarm/service/command/AlarmReadService.java
@@ -1,0 +1,32 @@
+package com.example.backend.domain.alarm.service.command;
+
+import com.example.backend.domain.alarm.entity.Alarm;
+import com.example.backend.domain.alarm.repository.AlarmRepository;
+import com.example.backend.domain.member.entity.Member;
+import com.example.backend.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmReadService {
+
+    private final AlarmRepository alarmRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void read(Long memberId, Long alarmId) {
+        Member member = memberRepository.findOrThrow(memberId);
+        Alarm alarm = alarmRepository.findById(alarmId)
+                .orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
+
+        if (!alarm.getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("해당 알림에 접근 권한이 없습니다.");
+        }
+
+        if (!alarm.getIsRead()) {
+            alarm.markAsRead();
+        }
+    }
+}

--- a/src/main/java/com/example/backend/domain/event/service/command/EventCreateService.java
+++ b/src/main/java/com/example/backend/domain/event/service/command/EventCreateService.java
@@ -1,13 +1,19 @@
 package com.example.backend.domain.event.service.command;
 
+import com.example.backend.domain.alarm.entity.AlarmType;
+import com.example.backend.domain.alarm.service.command.AlarmCreateService;
 import com.example.backend.domain.event.dto.EventCreateRequest;
 import com.example.backend.domain.event.dto.EventResponse;
 import com.example.backend.domain.event.entity.Event;
 import com.example.backend.domain.event.repository.EventRepository;
+import com.example.backend.domain.like.entity.StoreLike;
+import com.example.backend.domain.like.repository.StoreLikeRepository;
 import com.example.backend.domain.member.entity.Member;
 import com.example.backend.domain.member.repository.MemberRepository;
 import com.example.backend.domain.store.entity.Store;
 import com.example.backend.domain.store.repository.StoreRepository;
+
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +26,8 @@ public class EventCreateService {
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
     private final EventRepository eventRepository;
+    private final AlarmCreateService alarmCreateService;
+    private final StoreLikeRepository storeLikeRepository;
 
     public EventResponse save(Long memberId, Long storeId, EventCreateRequest eventCreateRequest) {
         Member member = memberRepository.findOrThrow(memberId);
@@ -27,6 +35,15 @@ public class EventCreateService {
         validateIsOwner(member, store);
 
         Event event = eventRepository.save(eventCreateRequest.toEntity(store));
+        List<StoreLike> likes = storeLikeRepository.findAllByStore(store);
+        for (StoreLike like : likes) {
+            alarmCreateService.create(
+                    like.getMember().getId(),
+                    store.getName() + "에 새로운 이벤트가 등록되었습니다!",
+                    AlarmType.NEW_EVENT,
+                    "/store/" + store.getId() + "/event/" + event.getId()
+            );
+        }
         return EventResponse.from(event);
     }
 

--- a/src/main/java/com/example/backend/domain/like/repository/StoreLikeRepository.java
+++ b/src/main/java/com/example/backend/domain/like/repository/StoreLikeRepository.java
@@ -13,4 +13,5 @@ import java.util.Optional;
 public interface StoreLikeRepository extends JpaRepository<StoreLike,Long> {
     Optional<StoreLike> findByMemberAndStore(Member member, Store store);
     List<StoreLike> findAllByMember(Member member);
+    List<StoreLike> findAllByStore(Store store);
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
상점에 이벤트가 등록되면 해당 상점을 좋아요 한 회원에게 실시간 알림이 전송되도록 구현

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- Alarm 도메인 기능 확장 (AlarmType, targetUrl 추가)
- 이벤트 등록 시 알림 자동 전송
- 테스트 코드 추가


## 📸 스크린샷 (선택)
<img width="1786" height="897" alt="스크린샷 2025-08-05 105338" src="https://github.com/user-attachments/assets/a6b95df5-849f-4136-ad86-b6300f417c22" />


## 💬 공유사항 to 리뷰어
현재는 Postman을 활용해 알림 생성 및 수신까지 정상 작동 확인했습니다. 
SSE 실시간 수신 테스트는 프론트 연동 후에 진행해보겠습니다.
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number
closes #56 
<!--- closes #이슈번호 ex) closes #123 -->
