### PR TITLE
[Feat] 관리자 대시보드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+	//QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -67,4 +73,22 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+
+def querydslDir = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(querydslDir)
 }

--- a/src/main/java/com/example/backend/domain/admin/controller/AdminDashboardController.java
+++ b/src/main/java/com/example/backend/domain/admin/controller/AdminDashboardController.java
@@ -1,0 +1,26 @@
+package com.example.backend.domain.admin.controller;
+
+import com.example.backend.domain.admin.dto.AdminDashboardResponse;
+import com.example.backend.domain.admin.service.AdminDashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/dashboard")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminDashboardController {
+
+    private final AdminDashboardService adminDashboardService;
+
+    @GetMapping
+    public ResponseEntity<AdminDashboardResponse> getDashboard(){
+        AdminDashboardResponse response = adminDashboardService.getAdminDashboard();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/backend/domain/admin/dto/AdminDashboardResponse.java
+++ b/src/main/java/com/example/backend/domain/admin/dto/AdminDashboardResponse.java
@@ -1,0 +1,10 @@
+package com.example.backend.domain.admin.dto;
+
+import java.util.List;
+
+public record AdminDashboardResponse(
+        long totalStoreCount, // 서비스에 가입한 상점 수
+        List<StoreEventVisitStats> eventStats, // 상점별/이벤트별 이용객 통계
+        List<MonthlyStoreVisitStats> monthlyStats // 월별 이용객 통계
+) {
+}

--- a/src/main/java/com/example/backend/domain/admin/dto/MonthlyStoreVisitStats.java
+++ b/src/main/java/com/example/backend/domain/admin/dto/MonthlyStoreVisitStats.java
@@ -1,0 +1,10 @@
+package com.example.backend.domain.admin.dto;
+
+public record MonthlyStoreVisitStats(
+        Long storeId,
+        String storeName,
+        Integer year,
+        Integer month,
+        Integer visitorCount
+) {
+}

--- a/src/main/java/com/example/backend/domain/admin/dto/StoreEventVisitStats.java
+++ b/src/main/java/com/example/backend/domain/admin/dto/StoreEventVisitStats.java
@@ -1,0 +1,14 @@
+package com.example.backend.domain.admin.dto;
+
+import java.time.LocalDateTime;
+
+public record StoreEventVisitStats(
+        Long storeId,
+        String storeName,
+        Long eventId,
+        String eventTitle,
+        LocalDateTime eventStart,
+        LocalDateTime eventEnd,
+        Integer visitorCount
+) {
+}

--- a/src/main/java/com/example/backend/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/example/backend/domain/admin/service/AdminDashboardService.java
@@ -1,0 +1,26 @@
+package com.example.backend.domain.admin.service;
+
+import com.example.backend.domain.admin.dto.AdminDashboardResponse;
+import com.example.backend.domain.admin.dto.MonthlyStoreVisitStats;
+import com.example.backend.domain.admin.dto.StoreEventVisitStats;
+import com.example.backend.domain.store.repository.StoreDailyVisitorRepository;
+import com.example.backend.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDashboardService {
+
+    private final StoreDailyVisitorRepository storeDailyVisitorRepository;
+
+    public AdminDashboardResponse getAdminDashboard() {
+        long visitorCount = storeDailyVisitorRepository.countJoinedStores();
+        List<StoreEventVisitStats> eventVisitStats = storeDailyVisitorRepository.getStoreEventVisitStats();
+        List<MonthlyStoreVisitStats> monthlyVisitStats = storeDailyVisitorRepository.getMonthlyVisitStats();
+
+        return new AdminDashboardResponse(visitorCount, eventVisitStats, monthlyVisitStats);
+    }
+}

--- a/src/main/java/com/example/backend/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/backend/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -21,7 +21,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         // 인증 불필요 경로 예외 처리
         String uri = request.getRequestURI();
-        if (uri.startsWith("/api/auth")) {
+        if (uri.startsWith("/api/auth") && !uri.equals("/api/auth/logout")) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if ("access_token".equals(cookie.getName())) {
+                if ("accessToken".equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }

--- a/src/main/java/com/example/backend/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/backend/domain/auth/jwt/JwtTokenProvider.java
@@ -63,9 +63,9 @@ public class JwtTokenProvider {
         Date refreshTokenExpires = Date.from(refreshTokenExpiryDateTime.atZone(ZoneId.systemDefault()).toInstant());
 
         // 인증 정보 가져오기
-        String username = authentication.getName();
-        Member user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new RuntimeException("User not found with username: " + username));
+        String email = authentication.getName();
+        Member user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found with email: " + email));
 
 
         String accessToken = Jwts.builder()
@@ -100,9 +100,9 @@ public class JwtTokenProvider {
             throw new RuntimeException("권한 정보가 없는 토큰");
         }
 
-        String username = claims.getSubject();
+        String email = claims.getSubject();
 
-        Member user = userRepository.findByUsername(username)
+        Member user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자"));
 
 
@@ -165,7 +165,7 @@ public class JwtTokenProvider {
             refreshTokenRepository.save(refreshToken);
         }
         redisTemplate.opsForValue().set(
-                "refresh_token:" + member.getUsername(),
+                "refreshToken:" + member.getEmail(),
                 token,
                 Duration.between(LocalDateTime.now(), expiryDate)
         );
@@ -207,8 +207,8 @@ public class JwtTokenProvider {
     }
 
     @Transactional
-    public void deleteRefreshTokenByUsername(String username) {
-        userRepository.findByUsername(username)
+    public void deleteRefreshTokenByUsername(String email) {
+        userRepository.findByEmail(email)
                 .ifPresent(this::deleteRefreshTokenByUser);
     }
   

--- a/src/main/java/com/example/backend/domain/auth/jwt/security/CustomUserDetails.java
+++ b/src/main/java/com/example/backend/domain/auth/jwt/security/CustomUserDetails.java
@@ -27,7 +27,7 @@ public class CustomUserDetails implements UserDetails, Serializable {
 
     @Override
     public String getUsername() {
-        return user.getUsername();
+        return user.getEmail();
     }
 
     @Override
@@ -48,6 +48,8 @@ public class CustomUserDetails implements UserDetails, Serializable {
     public Long getUserId() {
         return user.getId();
     }
+
+    public String getUserName() {return user.getUsername();}
 
     public String getRole() { return user.getRole().name(); }
 }

--- a/src/main/java/com/example/backend/domain/auth/jwt/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/backend/domain/auth/jwt/security/CustomUserDetailsService.java
@@ -15,9 +15,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final MemberRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자 없음 : " + username));
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자 없음 : " + email));
         return new CustomUserDetails(user);
     }
+
 }

--- a/src/main/java/com/example/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/backend/domain/auth/service/AuthService.java
@@ -47,8 +47,29 @@ public class AuthService {
         userRepository.save(user);
     }
 
+    public void signupAdmin(SignupRequest request) {
+        if (!request.getPassword().equals(request.getConfirmPassword())) {
+            throw new AuthException(AuthErrorCode.PASSWORD_MISMATCH);
+        }
+
+        if (userRepository.findByUsername(request.getUsername()).isPresent()) {
+            throw new AuthException(AuthErrorCode.USERNAME_ALREADY_EXISTS);
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        Member user = Member.builder()
+                .username(request.getUsername())
+                .email(request.getEmail())
+                .password(encodedPassword)
+                .role(Role.ADMIN)
+                .build();
+
+        userRepository.save(user);
+    }
+
     public JwtToken signin(SigninRequest request) {
-        // username / password 검증
+        // email / password 검증
         Authentication auth = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         request.getEmail(),

--- a/src/main/java/com/example/backend/domain/global/config/QuerydslConfig.java
+++ b/src/main/java/com/example/backend/domain/global/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.example.backend.domain.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/example/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/backend/domain/member/repository/MemberRepository.java
@@ -11,4 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
                 .orElseThrow(() -> new IllegalArgumentException("not found")); // 에러코드 추후 통일화 필요
     }
     Optional<Member> findByUsername(String username);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/example/backend/domain/store/entity/StoreDailyVisitor.java
+++ b/src/main/java/com/example/backend/domain/store/entity/StoreDailyVisitor.java
@@ -1,0 +1,32 @@
+package com.example.backend.domain.store.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreDailyVisitor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Store store;
+
+    private LocalDateTime visitDate;
+
+    private int paymentCount; //결제(이용객) 수
+
+    public StoreDailyVisitor(Long id, Store store, LocalDateTime visitDate, int paymentCount) {
+        this.id = id;
+        this.store = store;
+        this.visitDate = visitDate;
+        this.paymentCount = paymentCount;
+    }
+}

--- a/src/main/java/com/example/backend/domain/store/repository/StoreDailyVisitorCustom.java
+++ b/src/main/java/com/example/backend/domain/store/repository/StoreDailyVisitorCustom.java
@@ -1,0 +1,12 @@
+package com.example.backend.domain.store.repository;
+
+import com.example.backend.domain.admin.dto.MonthlyStoreVisitStats;
+import com.example.backend.domain.admin.dto.StoreEventVisitStats;
+
+import java.util.List;
+
+public interface StoreDailyVisitorCustom {
+    long countJoinedStores();
+    List<StoreEventVisitStats> getStoreEventVisitStats();
+    List<MonthlyStoreVisitStats> getMonthlyVisitStats();
+}

--- a/src/main/java/com/example/backend/domain/store/repository/StoreDailyVisitorRepository.java
+++ b/src/main/java/com/example/backend/domain/store/repository/StoreDailyVisitorRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.domain.store.repository;
+
+import com.example.backend.domain.store.entity.StoreDailyVisitor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreDailyVisitorRepository extends JpaRepository<StoreDailyVisitor, Long> , StoreDailyVisitorCustom{
+}

--- a/src/main/java/com/example/backend/domain/store/repository/StoreDailyVisitorRepositoryImpl.java
+++ b/src/main/java/com/example/backend/domain/store/repository/StoreDailyVisitorRepositoryImpl.java
@@ -1,0 +1,99 @@
+package com.example.backend.domain.store.repository;
+
+import com.example.backend.domain.admin.dto.MonthlyStoreVisitStats;
+import com.example.backend.domain.admin.dto.StoreEventVisitStats;
+import com.example.backend.domain.event.entity.QEvent;
+import com.example.backend.domain.store.entity.QStore;
+import com.example.backend.domain.store.entity.QStoreDailyVisitor;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class StoreDailyVisitorRepositoryImpl implements StoreDailyVisitorCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long countJoinedStores() {
+        QStore store = QStore.store;
+        Long count = queryFactory
+                .select(store.count())
+                .from(store)
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    @Override
+    public List<StoreEventVisitStats> getStoreEventVisitStats() {
+        QEvent event = QEvent.event;
+        QStoreDailyVisitor visitor = QStoreDailyVisitor.storeDailyVisitor;
+
+        return queryFactory
+                .select(Projections.constructor(StoreEventVisitStats.class,
+                        event.store.id,
+                        event.store.name,
+                        event.id,
+                        event.eventInfo.title,
+                        event.eventDuration.startTime,
+                        event.eventDuration.endTime,
+                        visitor.paymentCount.sum()
+                ))
+                .from(event)
+                .join(visitor).on(
+                        visitor.store.id.eq(event.store.id)
+                                .and(visitor.visitDate.between(event.eventDuration.startTime,
+                                        event.eventDuration.endTime))
+                )
+                .groupBy(event.id)
+                .fetch();
+    }
+
+    @Override
+    public List<MonthlyStoreVisitStats> getMonthlyVisitStats() {
+        QStoreDailyVisitor visitor = QStoreDailyVisitor.storeDailyVisitor;
+        QStore store = QStore.store;
+
+        return queryFactory
+                .select(Projections.constructor(MonthlyStoreVisitStats.class,
+                        visitor.store.id,
+                        visitor.store.name,
+                        visitor.visitDate.year(),
+                        visitor.visitDate.month(),
+                        visitor.paymentCount.sum()
+                ))
+                .from(visitor)
+                .join(visitor.store, store)
+                .groupBy(
+                        visitor.store.id,
+                        visitor.store.name,
+                        visitor.visitDate.year(),
+                        visitor.visitDate.month())
+                .fetch();
+    }
+
+//    @Override
+//    public List<MonthlyStoreVisitStats> getMonthlyVisitStats(Long storeId) {
+//        QStoreDailyVisitor visitor = QStoreDailyVisitor.storeDailyVisitor;
+//        QStore store = QStore.store;
+//
+//        return queryFactory
+//                .select(Projections.constructor(MonthlyStoreVisitStats.class,
+//                        visitor.store.id,
+//                        visitor.store.name,
+//                        visitor.visitDate.year(),
+//                        visitor.visitDate.month(),
+//                        visitor.paymentCount.sum()
+//                ))
+//                .from(visitor)
+//                .join(visitor.store, store)
+//                .where(visitor.store.id.eq(storeId))
+//                .groupBy(
+//                        visitor.store.id,
+//                        visitor.store.name,
+//                        visitor.visitDate.year(),
+//                        visitor.visitDate.month())
+//                .fetch();
+//    }
+}


### PR DESCRIPTION
Refactor: Auth에서 username -> email 변경 및 access/refreshToken 이름 변경

<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
관리자 대시보드 기능 구현 / [Auth] username -> email 변경 및 access/refreshToken 이름 변경

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- QueryDSL config 파일 생성 및 Q객체 생성
- 관리자 회원가입 및 로그인 기능 구현
- 관리자 대시보드 기능 구현(총 서비스 가입 상점 수, 이벤트 기간 별 이용객 수, 월간 상점 이용객 수)
- [Auth] 회원가입 및 로그인 기능에서 username을 받는 변수들을 email로 받도록 변경
- [Auth] access_token,refresh_token -> accessToken, refreshToken으로 이름 변경
- [Auth] 인증 불필요 경로 예외 처리에서 로그아웃 경로는 인증 필요로 변경


## 📸 스크린샷 (선택)

<img width="1489" height="421" alt="스크린샷 2025-08-05 오후 4 36 54" src="https://github.com/user-attachments/assets/5808f077-a836-4215-adc1-5c981553ea72" />
<img width="1315" height="421" alt="스크린샷 2025-08-05 오후 4 36 34" src="https://github.com/user-attachments/assets/68b7997a-1517-48e0-b413-1a1ef106479f" />
<img width="1015" height="546" alt="스크린샷 2025-08-05 오후 4 37 22" src="https://github.com/user-attachments/assets/81c8a83a-8b84-497d-85cc-5c63ab0baeba" />

-------

<img width="882" height="858" alt="스크린샷 2025-08-05 오후 4 38 08" src="https://github.com/user-attachments/assets/2f5b3c30-eae9-4bfc-b95a-02a5925447c1" />


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->
@hwan2-99 
Store 패키지에 StoreDailyVisitor Entity와 StoreDailyVisitorRepository,Custom,Impl 파일이 추가되었습니다.
프로젝트 빌드 후 테스트를 했을 때는 충돌사항이 없었습니다만, 만일을 대비해 확인해주시면 감사하겠습니다!
 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number

<!--- closes #이슈번호 ex) closes #123 -->
#53 