### PR TITLE
[Fix] 게시글 중복 조회 버그 해결

### DIFF
--- a/src/main/java/com/example/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/backend/domain/post/repository/PostRepository.java
@@ -12,8 +12,6 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long> , PostRepositoryCustom {
     Page<Post> findAllByStoreIdOrderByCreatedAtDesc(Long storeId, Pageable pageable);
 
-//    Page<Post> findAllOrderByCreatedAtDesc(Pageable pageable);
-
     default Post findOrThrow(Long id) {
         return findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));

--- a/src/main/java/com/example/backend/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/example/backend/domain/post/service/PostQueryService.java
@@ -42,16 +42,7 @@ public class PostQueryService {
         return PostResponse.of(post, mediaUrls, post.getStore());
     }
 
-//    public Page<PostResponse> getRecentPosts(Pageable pageable) {
-//        Page<Post> posts = postRepository.findAllOrderByCreatedAtDesc(pageable);
-//
-//        return posts.map(post -> {
-//            List<String> mediaUrls = postMediaRepository.findAllByPost(post).stream()
-//                    .map(PostMedia::getMediaUrl)
-//                    .toList();
-//            return PostResponse.of(post, mediaUrls, post.getStore());
-//        });
-//    }
+
 
     public Page<PostResponse> getRecentPosts(Pageable pageable) {
         return postRepository.findAllRecentPosts(pageable);


### PR DESCRIPTION
<!-- 
📝 PR 제목 작성 가이드 (지우지 말고 참고용으로 유지해주세요!)

[Feat] 기능 간단 요약
[Fix] 버그 간단 설명
[Refactor] 리팩토링 요약
[Docs] 문서 작업 요약
[Test] 테스트 코드 관련 작업
[Deploy] 배포 관련 설정 작업
[Chore] 기타 작업

ex) [Feat] 댓글 작성 API 구현
-->


## 📝 작업 내용 요약

<!-- 무엇을 수정했는지 한 줄로 요약해주세요 -->
게시글 중복 조회 버그 해결

## 🛠️ 작업 내용

<!-- 무엇을 했는지 구체적으로 적어주세요.  -->
- 게시글의 전체 조회 시 중복 조회 이슈 발생
- 게시글 1개가 이미지 2개를 가지고 있다면, 조인 결과로 post와 media 조합이 N(게시글) * M(이미지) 행수로 반환
- 조인 결과 자체는 게시글-이미지 갯수만큼 중복된 row가 반환되는 것으로 보임
- PostId 기준 그룹핑 -> 중복 제거 후 매핑


## 📸 스크린샷 (선택)
<img width="908" height="527" alt="스크린샷 2025-08-07 오전 9 56 09" src="https://github.com/user-attachments/assets/7adb70d4-54e4-4ced-8bbc-cd9cfab3ccb4" />



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분, 논의해야할 부분이 있으면 적어주세요. -->


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


## #️⃣ Issue Number

<!--- closes #이슈번호 ex) closes #123 -->
#78 